### PR TITLE
update(src/translate/index.js): includes error handling for welcome s…

### DIFF
--- a/public/src/client.js
+++ b/public/src/client.js
@@ -1,2 +1,9 @@
-const name = 'Lena'  
-console.log(name)
+'use strict';
+
+require('./app');
+
+// scripts-client.js is generated during build, it contains javascript files
+// from plugins that add files to "scripts" block in plugin.json
+require('../scripts-client');
+
+app.onDomReady();

--- a/public/src/client.js
+++ b/public/src/client.js
@@ -1,9 +1,2 @@
-'use strict';
-
-require('./app');
-
-// scripts-client.js is generated during build, it contains javascript files
-// from plugins that add files to "scripts" block in plugin.json
-require('../scripts-client');
-
-app.onDomReady();
+const name = 'Lena'  
+console.log(name)

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,17 +1,45 @@
-
 /* eslint-disable strict */
-//var request = require('request');
 
-const translatorApi = module.exports;
+const translatorApi = {};
 
-translatorApi.translate = function (postData) {
-	return ['is_english',postData];
-};
+// Base URL of your translator microservice
+// Allows override via env var in case CI/production uses a different host
+const DEFAULT_TRANSLATOR_API = 'http://128.2.220.234:5000';
 
 translatorApi.translate = async function (postData) {
-//  team11: east coasters
-const TRANSLATOR_API = "http://128.2.220.234:5000"
-const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
-const data = await response.json();
-return [data.is_english,data.translated_content];
+	// Support both { content: '...'} and raw string just in case
+	const content = postData && (postData.content || postData);
+
+	// If there's nothing to translate, return safe defaults
+	if (!content) {
+		return [true, ''];
+	}
+
+	const baseUrl = process.env.TRANSLATOR_API || DEFAULT_TRANSLATOR_API;
+
+	try {
+		const url = `${baseUrl}/?content=${encodeURIComponent(content)}`;
+		const response = await fetch(url);
+
+		if (!response.ok) {
+			throw new Error(`translator responded with status ${response.status}`);
+		}
+
+		const data = await response.json();
+
+		const isEnglish = (typeof data.is_english === 'boolean') ? data.is_english : true;
+		const translated = data.translated_content || content;
+
+		// Keep the same return shape your other code expects: [is_english, translated_content]
+		return [isEnglish, translated];
+	} catch (err) {
+		// 🔴 IMPORTANT: don't let this kill setup/CI
+		// NodeBB has winston, but console.warn is fine for your project
+		console.warn('[translator] fetch failed, using fallback:', err.message);
+
+		// Fallback: assume English and use original content
+		return [true, content];
+	}
 };
+
+module.exports = translatorApi;


### PR DESCRIPTION
Added error handling to fix the type error: fetch failed: 

We intentionally chose not to merge this version and keep our main branch the way that it is, which produces a TypeError: fetch failed during GitHub Actions setup, because it represents the most stable and functional implementation of our translation feature in the actual deployed NodeBB environment. When I attempted to “fix” this error to satisfy CI, the setup either timed out or caused the translation feature to stop working entirely (see error message). The fetch failed error only appears in the automated GitHub Actions environment, where the Flask microservice cannot be reached, but in the real deployment, the translator works as intended. Since the main goal of this project is to demonstrate a functioning LLM integration within NodeBB, we prioritized preserving the working version that correctly sends and retrieves translated content from the microservice.